### PR TITLE
 Avoid pulling image if it already exists locally

### DIFF
--- a/main.go
+++ b/main.go
@@ -155,6 +155,13 @@ func runUserImage(cli *client.Client, image string, hostname string) error {
 }
 
 func pullImage(cli *client.Client, image string) error {
+	// Check if image already exists locally
+	_, _, err := cli.ImageInspectWithRaw(context.Background(), image)
+	if err == nil {
+		return nil
+	}
+
+	// Image doesn't exist locally, pull it
 	out, err := cli.ImagePull(context.Background(), image, types.ImagePullOptions{})
 	if err != nil {
 		return err


### PR DESCRIPTION
We use https://github.com/tinkerbell/hook?tab=readme-ov-file#embedding-container-images-into-the-dind-docker-in-docker-also-known-as-hook-docker-container, and without this patch, docker tries to pull the image even when it already exists locally